### PR TITLE
Add flowgen command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest",
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "flowgen": "for i in $(find dist -type f -name '*.d.ts'); do sh -c \"flowgen $i -o ${i%.*.*}.js.flow\"; done;",
     "lint": "tslint -p tsconfig.json --fix"
   },
   "repository": {


### PR DESCRIPTION
In Yoroi we use Flow and not Typescript. There is a utility tool called "Flowgen" that can generate Flow type definitions from Typescript definitions. I'm just adding this to the `package.json` so I can easily run it for later updates (you don't have to publish the flow definitions as part of the package if you don't want to guarantee they work).
The tool doesn't work perfectly on this repo because `address.ts` uses getter notation which flowgen doesn't support at the moment (but hopefully will in the future).