### PR TITLE
Add checked constructors

### DIFF
--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -18,7 +18,7 @@ export enum AddressKind {
 };
 
 export class Address {
-  get publicKey(): string {
+  get publicKey(): Buffer {
     return this.addrBytes.slice(1, 34);
   }
 
@@ -69,6 +69,19 @@ export class Address {
   constructor(address: string) {
     this.address = address;
     this.addrBytes = bs58.decode(this.address);
+  }
+
+  public static fromBase58(address: string): Address {
+    const addr = new Address(address);
+    if (!addr.isValid()) {
+      throw new Error(`Invalid Ergo address ${address}`);
+    }
+    return addr;
+  }
+
+  public static fromBytes(bytes: Buffer): Address {
+    const address = bs58.encode(bytes);
+    return Address.fromBase58(address);
   }
 
   public isValid(): boolean {

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -64,7 +64,7 @@ export class Address {
   }
 
   public address: string;
-  public addrBytes;
+  public addrBytes: Buffer;
 
   constructor(address: string) {
     this.address = address;

--- a/tests/address.test.ts
+++ b/tests/address.test.ts
@@ -115,3 +115,27 @@ test('address from sk', () => {
   });
 
 });
+
+test('checked construction from base58', () => {
+  testVectors.forEach((o) => {
+    if (o.isValid) {
+      expect(() => Address.fromBase58(o.address.address))
+        .not.toThrow();
+    } else {
+      expect(() => Address.fromBase58(o.address.address))
+        .toThrow();
+    }
+  });
+});
+
+test('checked construction from bytes', () => {
+  testVectors.forEach((o) => {
+    if (o.isValid) {
+      expect(() => Address.fromBytes(o.address.addrBytes))
+        .not.toThrow();
+    } else {
+      expect(() => Address.fromBytes(o.address.addrBytes))
+        .toThrow();
+    }
+  });
+});


### PR DESCRIPTION
I found is strange that the constructor for `Address` silently accepts invalid addresses and that you need to manually check validity with `isValid`. I think this can easily be error-prone, so I added checked factory methods.

I noticed in other places you use the `throw` notation to signal errors, so I did the same for these methods.

We could also consider making the `Address` constructor is private if you want, but I didn't do this so that this PR is backwards-compatible.