### PR TITLE
Fix fee check during transaction building

### DIFF
--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -38,7 +38,9 @@ export class Transaction implements IIdObject {
   }
 
   private static createFee(payloadOutputs: ErgoBox[], height: number, fee: number): ErgoBox[] {
-    if (payloadOutputs.find(o => o.address === feeMainnetAddress || o.address === feeTestnetAddress)) {
+    if (payloadOutputs.find(o => (
+      o.address.address === feeMainnetAddress.address || o.address.address === feeTestnetAddress.address)
+    )) {
       return [];
     } else {
       return [new ErgoBox('', fee, height, feeMainnetAddress)];

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -1,7 +1,7 @@
 import * as constants from './testConstants.js';
 import { ErgoBox } from '../src/models/ergoBox';
 import { Transaction } from '../src/models/transaction';
-
+import { Address } from '../src/models/address';
 
 test('from outputs', () => {
 
@@ -12,6 +12,26 @@ test('from outputs', () => {
   const payloadOutputs = [new ErgoBox('', tokensToTransfer, 0, recipient)];
   const tx = Transaction.fromOutputs(boxesToSpend, payloadOutputs);
 
+  const totalValueOut = tx.outputs.reduce((sum, { value }) => sum + value, 0);
+  expect(totalValueIn)
+    .toEqual(totalValueOut);
+
+});
+
+test('from outputs w/ fee pre-included', () => {
+
+  const boxesToSpend = constants.boxesToSpend;
+  const recipient = constants.newAddress;
+  const totalValueIn = boxesToSpend.reduce((sum, { value }) => sum + value, 0);
+  const tokensToTransfer = 12345;
+  
+  const payloadOutputs = [
+    new ErgoBox('', tokensToTransfer, 0, recipient), // regular output
+    new ErgoBox('', 1000000, 0, Address.fromBase58(constants.feeMainnetAddress)), // explicit fee
+  ];
+  const tx = Transaction.fromOutputs(boxesToSpend, payloadOutputs);
+  
+  expect(tx.outputs).toHaveLength(3);
   const totalValueOut = tx.outputs.reduce((sum, { value }) => sum + value, 0);
   expect(totalValueIn)
     .toEqual(totalValueOut);


### PR DESCRIPTION
**Background:**

When ergo-ts does input selection, it checks if the transaction already has a box for the fee (and if it doesn't, it creates one for you)

**Problem:**

The check for whether or not the fee was already included doesn't check if the address itself is the fee address, but rather whether or not it's the constant fee **object**. Object comparison in JS does not do field-wise comparison and instead check if the object itself is the same reference.

**Solution:**

This new code properly checks the fee address is the same by comparing the address base58 content